### PR TITLE
Fixes setup.py to work with python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from distutils.core import setup
 
 
-if sys.version_info.major == 3:
+if sys.version_info[0] == 3:
     author_name = 'Álvaro Justen'
 else:
     author_name = 'Álvaro Justen'.decode('utf-8')


### PR DESCRIPTION
In python 2.6 sys.version_info is a regular tuple, not a NamedTuple. This means
sys.version_info.major does not work. Since using the index works in python 2.7
(and python 3) this patch should make setup.py work in any version.
